### PR TITLE
fix "Maximum call stack size exceeded"

### DIFF
--- a/src/walker.coffee
+++ b/src/walker.coffee
@@ -43,7 +43,7 @@ class Walker extends EventEmitter
             @emit 'change:dir', path, stats, list
         @_watcher.on 'change:file', (path, stats) =>
             @emit 'change', path, stats
-        @_watcher.on 'error', (path, error) ->
+        @_watcher.on 'error', (path, error) =>
             @emit 'error', path, error
         @on 'file', (path) ->
             @_watcher.addFile path


### PR DESCRIPTION
I encountered a deep stack problem when emit `error` event.

```
RangeError: Maximum call stack size exceeded
```

fixed lib/walker.js

``` javascript
      this._watcher.on('error', function(path, error) {
        return this.emit('error', path, error);
      });
```
